### PR TITLE
A single search field can no longer be removed

### DIFF
--- a/src/app/modules/mask/components/super-search/super-search.component.css
+++ b/src/app/modules/mask/components/super-search/super-search.component.css
@@ -67,6 +67,10 @@
   background-color: var(--color-aswwu-danger);
 }
 
+.remove-button:hover:disabled {
+  background-color: grey;
+}
+
 /* for mobile */
 
 #search-area {

--- a/src/app/modules/mask/components/super-search/super-search.component.html
+++ b/src/app/modules/mask/components/super-search/super-search.component.html
@@ -31,7 +31,7 @@
                 <!--TODO: put ryan's datalist component in here instead of basic html datalist-->
 
                 <!-- REMOVE BUTTON -->
-                <button class="btn super-search-box mask-search-query remove-button" (click)="removeField(i)"><span class="fas fa-times"></span></button>
+                <button class="btn super-search-box mask-search-query remove-button" [disabled]="singleField" (click)="removeField(i)"><span class="fas fa-times"></span></button>
             </div>
             <!-- YEAR SELECTOR -->
             <div class="text-center">
@@ -49,7 +49,7 @@
                         <option value="1213">2012-2013</option>
                     </select>
                 </div>
-                <button class="btn btn-success btn-sm" (click)="criteria.push(['', ''])">Add search field</button>
+                <button class="btn btn-success btn-sm" (click)="addField()">Add search field</button>
             </div>
             <button class="btn btn-primary search-button col col-md-4 offset-md-4" (click)="updateQuery()">Search!</button>
         </div>

--- a/src/app/modules/mask/components/super-search/super-search.component.ts
+++ b/src/app/modules/mask/components/super-search/super-search.component.ts
@@ -24,6 +24,7 @@ export class SuperSearchComponent implements OnInit {
     fieldsInOrder: string[] = FieldsForSearching;
     selectables: any = SelectFields;
     searchables: any = SearchableFields;
+    singleField = true;
 
     private subscription: Subscription;
 
@@ -53,7 +54,7 @@ export class SuperSearchComponent implements OnInit {
     updateQuery() {
         let tempstring = '';
         for (const value of this.criteria) {
-            if (value[0] !== 'year' && value[1] !== ''){
+            if (value[0] !== 'year' && value[1] !== '') {
                 tempstring += value[0] + '=' + value[1] + '&';
             } else if (value[0] === 'year') {
                 this.year = value[1];
@@ -62,17 +63,18 @@ export class SuperSearchComponent implements OnInit {
         tempstring = tempstring.slice(0, -1);
         this.query = tempstring;
         this.serverQuery = this.query.replace('&', ';');
-        this.location.replaceState('/super-search?' + this.query);
+        this.location.replaceState('/mask/super-search?' + this.query);
+    }
+
+    addField() {
+      this.criteria.push(['', '']);
+      this.singleField = false;
     }
 
     removeField(i) {
         this.criteria.splice(i, 1);
-        // let i = 0;
-        // for(let pair of this.criteria) {
-        //     if(pair[1].indexOf(search)){
-        //         this.criteria.splice(i, 1);
-        //     }
-        //     i++;
-        // }
+        if (this.criteria.length === 1) {
+          this.singleField = true;
+        }
     }
 }


### PR DESCRIPTION
When there is only one search field in super-search the remove button is now disabled but becomes available again when more than one search field gets added. 