### PR TITLE
Mask no longer auto selects on search

### DIFF
--- a/src/app/modules/mask/components/search/search.component.html
+++ b/src/app/modules/mask/components/search/search.component.html
@@ -2,7 +2,7 @@
   <div class="align-items-center" (keyup.enter)="runSearch()" style="margin-left:auto;margin-right:auto;">
     <br />
     <div class="row justify-content-center">
-      <input id="mask-search-query" class="search-area-element col form-control" [(ngModel)]='typedQuery' (ngModelChange)="addFirstResult()" (selectItem)="runSearch($event)" [ngbTypeahead]="typeaheadSearch" [resultFormatter]="typeaheadFormatter" type="text" placeholder="Find the one...">
+      <input id="mask-search-query" class="search-area-element col form-control" [(ngModel)]='typedQuery' (ngModelChange)="addFirstResult()" (selectItem)="runSearch($event)" [ngbTypeahead]="typeaheadSearch" [focusFirst]="false" [resultFormatter]="typeaheadFormatter" type="text" placeholder="Find the one...">
       <div class="input-group-append">
         <button id="mask-search-button" class="search-area-element col-1 form-control" (click)="runSearch()"><i class="fas fa-search"></i></button>
       </div>


### PR DESCRIPTION
When searching on the mask's homepage, the autofill feature no longer auto selects allowing users to make custom searches more easily. 